### PR TITLE
change ProtoType2

### DIFF
--- a/Prototype/kep/tmp.txt
+++ b/Prototype/kep/tmp.txt
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <!-- query time: 0.0126 sec -->
+  </head>
+  <boolean>true</boolean>
+</sparql>
+

--- a/Prototype2/explorer/BookExplorer.java
+++ b/Prototype2/explorer/BookExplorer.java
@@ -1,8 +1,10 @@
 package explorer;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Scanner;
+import java.util.Iterator;
 
 import org.dom4j.DocumentException;
 
@@ -22,12 +24,10 @@ public class BookExplorer {
 		CreateRequest cr = new CreateRequest(); // リクエスト作成
 		RequestTR rtr = new RequestTR(); // リクエスト送受信
 		ResultAnalyzer3 ra = new ResultAnalyzer3(); // 結果解析
-		BookExplorer be = new BookExplorer();
+		GetData gd = new GetData();
 
 		//とりあえず、最初に初期クエリを入力
-		Scanner scan = new Scanner(System.in);
-		System.out.print("キーワード：");
-		String keyword = scan.nextLine();
+		String keyword = input();
 		System.out.println("入力キーワード > " + keyword);
 
 		/*
@@ -69,13 +69,53 @@ public class BookExplorer {
 		/*
 		 * スタート本の件名、分類から、関連キーワードを取得(SubjectDataの作成)
 		 */
-		 scan.close();
-		 Scanner scan2 = new Scanner(System.in);
-		 System.out.print("選択：");
-		 String select = scan2.nextLine();
+		 String select = input();
+		 int sn = Integer.parseInt(select);
+
+		 BookData target = normalBookData.get(sn);
+		 target.checkBookData();
+		 System.out.println("以下は取得できたキーワード");
+		 ArrayList<String> sub = target.getSubject();
+		 String key = null;
+		 for(String tmp : sub) {
+			 key = tmp;
+		 }
+		 //典拠データの取得
+		 ArrayList<ArrayList<String>> result =gd.getSubjectData(key);
+		 ArrayList<String> wordList = new ArrayList<String>();
+		 wordList.addAll(gd.getDataList(result));
+		 wordList.addAll(gd.getDataList(gd.getSubjectData(result), true));
+
+		//普通件名でないものを除く
+			Iterator<String> it = wordList.iterator();
+	        while(it.hasNext()){
+	            String s = it.next();
+	            if(!ra.checkTorF(rtr.requestProcess(cr.getCheckIsNormalSubject(s)))) {
+	            	it.remove();
+	            }
+	        }
+	        wordList = gd.removeSameWord(wordList, keyword);
+
+	        for(String s : wordList) {
+	        	System.out.println(s);
+	        }
 
 		/*
 		 * 得られたデータの表示(とりあえず、CUIでやる)
 		 */
+	}
+
+	public static String input() {
+		 InputStreamReader isr = new InputStreamReader(System.in);
+		 BufferedReader br = new BufferedReader(isr);
+	     System.out.print("入力してください   ⇒  ");
+	     String str = null;;
+		try {
+			str = br.readLine();
+		} catch (IOException e) {
+			// TODO 自動生成された catch ブロック
+			e.printStackTrace();
+		}
+	     return str;
 	}
 }

--- a/Prototype2/explorer/GetData.java
+++ b/Prototype2/explorer/GetData.java
@@ -1,0 +1,124 @@
+package explorer;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+import exception.ArgsTypeException;
+import get_data.CreateRequest;
+import get_data.RequestTR;
+import get_data.ResultAnalyzer3;
+
+public class GetData {
+
+	public GetData() {
+		// TODO 自動生成されたコンストラクター・スタブ
+	}
+
+	public ArrayList<ArrayList<String>> getSubjectData(String keyword) {
+		CreateRequest cr = new CreateRequest(); // リクエスト作成
+		RequestTR rtr = new RequestTR(); // リクエスト送受信
+		ResultAnalyzer3 ra = new ResultAnalyzer3(); // 結果解析
+
+		ArrayList<ArrayList<String>> result = new ArrayList<ArrayList<String>>(); // 結果リスト（返り値）
+		ArrayList<String> bro = new ArrayList<String>(); // 上位語を格納するためのリスト
+		ArrayList<String> nar = new ArrayList<String>(); // 下位語を格納するためのリスト
+		ArrayList<String> rel = new ArrayList<String>(); // 関連語を格納するためのリスト
+		ArrayList<String> ndc = new ArrayList<String>(); // 代表分類を格納するためのリスト
+
+		try {
+			bro = ra.AnalyzeResult(rtr.requestProcess(cr.createRequest(keyword, "non", "broad")));
+			nar = ra.AnalyzeResult(rtr.requestProcess(cr.createRequest(keyword, "non", "narrow")));
+			rel = ra.AnalyzeResult(rtr.requestProcess(cr.createRequest(keyword, "non", "relate")));
+			ndc = ra.AnalyzeResult(rtr.requestProcess(cr.createRequest(keyword, "non", "ndc")), true);
+		} catch (ArgsTypeException e) {
+			e.printStackTrace();
+		}
+		// 結果リストへの格納
+		result.add(bro);
+		result.add(nar);
+		result.add(rel);
+		result.add(ndc);
+
+		return result;
+	}
+
+	public String[] getSubType(ArrayList<ArrayList<String>> check) {
+		String[] subType = null;
+		if (check.size() == 4) {
+			subType = new String[4];
+			subType[0] = "上位語";
+			subType[1] = "下位語";
+			subType[2] = "関連語";
+			subType[3] = "代表分類";
+		}
+		return subType;
+	}
+
+	public ArrayList<ArrayList<String>> getSubjectData(ArrayList<ArrayList<String>> result) {
+		ArrayList<ArrayList<String>> resNdc = new ArrayList<ArrayList<String>>();
+		ArrayList<String> ndc = result.get(3);
+
+		for (String l : ndc) {
+			if (l.contains("ndc9")) {
+				resNdc.add(this.getNDCData(l));
+			}
+		}
+		return resNdc;
+	}
+
+	public ArrayList<String> getNDCData(String target) {
+		CreateRequest cr = new CreateRequest(); // リクエスト作成
+		RequestTR rtr = new RequestTR(); // リクエスト送受信
+		ResultAnalyzer3 ra = new ResultAnalyzer3(); // 結果解析
+		ArrayList<String> result = new ArrayList<String>();
+
+		try {
+			result = ra.AnalyzeResult(rtr.requestProcess(cr.createRequest(target, "non", "relatedMatch")));
+		} catch (ArgsTypeException e) {
+			e.printStackTrace();
+		}
+
+		return result;
+	}
+
+	public ArrayList<String> getDataList(ArrayList<ArrayList<String>> target) {
+		int getDataNum = 3;// ここで入れたいのは上位語、下位語、関連語
+		ArrayList<String> result = new ArrayList<String>();
+
+		for (int i = 0; i < getDataNum; i++) {
+			result.addAll(target.get(i));
+		}
+
+		return result;
+	}
+
+	public ArrayList<String> getDataList(ArrayList<ArrayList<String>> target, boolean NDC) {
+		ArrayList<String> result = new ArrayList<String>();
+		ArrayList<String> tmp = null;
+
+		for (int i = 0; i < target.size(); i++) {
+			tmp = target.get(i);
+			result.addAll(tmp);
+		}
+
+		return result;
+	}
+
+	public ArrayList<String> removeSameWord(ArrayList<String> target, String keyword) {
+		ArrayList<String> result = new ArrayList<String>();
+		result = (ArrayList<String>) target.stream().distinct().collect(Collectors.toList());
+
+		// キーワードと同じものを削除
+		int removenum = 0;
+		for (int i = 0; i < result.size(); i++) {
+			String tmp = result.get(i);
+			if (tmp.matches(keyword)) {
+				removenum = i;
+				break;
+			}
+		}
+		result.remove(removenum);
+
+		return result;
+	}
+}

--- a/Prototype2/get_data/ResultAnalyzer3.java
+++ b/Prototype2/get_data/ResultAnalyzer3.java
@@ -83,8 +83,8 @@ public class ResultAnalyzer3 {
 	 */
 	public ArrayList<String> AnalyzeResult(String data, boolean NDC) throws ArgsTypeException {
 		if (NDC) {
-			//String tmpFilePath = "C:\\Users\\Shingo\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
-			String tmpFilePath = "C:\\Users\\AILab08\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
+			String tmpFilePath = "C:\\Users\\Shingo\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
+			//String tmpFilePath = "C:\\Users\\AILab08\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
 			ArrayList<String> result = new ArrayList<String>();
 			try {
 				File filetmp = new File(tmpFilePath);
@@ -421,8 +421,8 @@ public class ResultAnalyzer3 {
 
 
 	public boolean checkTorF(String data) {
-		//String tmpFilePath = "C:\\Users\\Shingo\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
-		String tmpFilePath = "C:\\Users\\AILab08\\git\\MyGRR\\Prototype\\kep3\\tmpc.txt";
+		String tmpFilePath = "C:\\Users\\Shingo\\git\\MyGRR\\Prototype\\kep\\tmp.txt";
+		//String tmpFilePath = "C:\\Users\\AILab08\\git\\MyGRR\\Prototype\\kep3\\tmpc.txt";
 		try {
 			File filetmp = new File(tmpFilePath);
 			BufferedWriter bw = new BufferedWriter(new FileWriter(filetmp));

--- a/Prototype2/get_data/tmp.txt
+++ b/Prototype2/get_data/tmp.txt
@@ -3,7 +3,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000000162679-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcterms:description>雑誌記事索引採録あり</dcterms:description>
@@ -78,7 +78,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000004086512-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1003,7 +1003,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000007343782-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1235,7 +1235,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000002760715-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1526,7 +1526,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000007036509-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1631,7 +1631,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I023454143-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1709,7 +1709,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000000411439-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -1783,7 +1783,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000011259481-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -2518,7 +2518,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I000000082197-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>
@@ -2612,7 +2612,7 @@
       info:srw/schema/1/dc-v1.1
       string
       
-<rdf:RDF xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dcterms="http://purl.org/dc/terms/">
+<rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dcndl="http://ndl.go.jp/dcndl/terms/" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:dcterms="http://purl.org/dc/terms/">
   <dcndl:BibAdminResource rdf:about="http://iss.ndl.go.jp/books/R100000002-I027611535-00">
     <dcndl:catalogingStatus>C7</dcndl:catalogingStatus>
     <dcndl:bibRecordCategory>R100000002</dcndl:bibRecordCategory>


### PR DESCRIPTION
足りない部分はまだあるが、とりあえず、本のデータの作成、そこから一つ選んで、その本の件名から関連キーワード（上位語、下位語、関連語、代表分類から取得した件名）を取得し、表示ができた

例えば、
いまは、関連キーワードはそのまま表示しているだけなので、それぞれが何なのか（上位語などのどれなのか）も一緒に表示する

入力してください   ⇒  人工知能
入力キーワード > 人工知能
-------------本情報------------
メインタイトル:AI事典
著作者名土屋俊 [ほか]編
出版社:共立出版
分類:NDC9:007.13
件名:人工知能
ISBN：4-320-12063-9
請求記号:請求記号：M2-H38
ページ数:523p ; 22cm
-------------本情報------------
メインタイトル:AIによる企業評価 : 人工知能を活かした知識モデルの試み
著作者名岡本大輔 著
出版社:中央経済社
分類:NDC9:336.83
件名:経営分析--データ処理
件名:人工知能
ISBN：4-502-37240-4
請求記号:請求記号：DH563-H78
ページ数:234p ; 22cm
-------------本情報------------
メインタイトル:AIは予言する : 人工知能がひらく驚異の世界
著作者名飯田弘之 著
出版社:エー・ジー
分類:NDC9:007.13
件名:人工知能
ISBN：4-900874-18-3
請求記号:請求記号：M121-G160
ページ数:200p ; 19cm
-------------本情報------------
メインタイトル:Excelで遊ぶ人工知能ニューラルネットワーク : Windows 7/Excel 2010
著作者名福山隆晃 著
出版社:三恵社
分類:NDC9:007.13
件名:ニューラルネットワーク
件名:プログラミング (コンピュータ)
ISBN：978-4-88361-941-2
請求記号:請求記号：M121-J210
ページ数:282p ; 26cm
-------------本情報------------
メインタイトル:IBM奇跡の"ワトソン"プロジェクト : 人工知能はクイズ王の夢をみる
著作者名スティーヴン・ベイカー 著
著作者名土屋政雄 訳
出版社:早川書房
分類:NDC9:007.13
件名:人工知能
ISBN：978-4-15-209236-6
請求記号:請求記号：M121-J187
ページ数:350p ; 19cm
-------------本情報------------
メインタイトル:Java人工知能プログラミング : オブジェクト指向と関数スタイルによるAIの実装
著作者名深井裕二 著
出版社:三恵社
分類:NDC9:007.13
件名:人工知能
件名:プログラミング (コンピュータ)
ISBN：978-4-86487-569-1
請求記号:請求記号：M121-L280
ページ数:275p ; 21cm
入力してください   ⇒  0
-------------本情報------------
メインタイトル:AI事典
著作者名土屋俊 [ほか]編
出版社:共立出版
分類:NDC9:007.13
件名:人工知能
ISBN：4-320-12063-9
請求記号:請求記号：M2-H38
ページ数:523p ; 22cm
以下は取得できたキーワード
情報科学
機械学習
ニューラルネットワーク
エキスパートシステム
問題解決
自動運転 (自動車)
ソフトコンピューティング
オントロジー (情報科学)
パターン認識
遺伝的アルゴリズム
オントロジー (情報科学)
人工知能
パターン認識
パーセプトロン
バイオメトリクス
音声認識
ニューラルネットワーク
自己組織化マップ
機械学習
深層学習